### PR TITLE
Dealer details flyout mobile fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ class DealerLocator extends React.Component {
       : DealerDetails;
 
     return (
-      <DealerLocatorWrapper>
+      <DealerLocatorWrapper visible={!!this.state.selectedDealer}>
         <SearchArea>
           <DealerSearch
             google={this.props.google}
@@ -203,7 +203,7 @@ class DealerLocator extends React.Component {
             filterOnlineDealers={this.state.isDealerFilterSelected}
           />
         </ListArea>
-        <MapArea>
+        <MapArea visible={!!this.state.selectedDealer}>
           <DealerMap
             dealers={this.dealersWithSelectedFlag()}
             initialCenter={defaultStartingLocation}
@@ -246,9 +246,8 @@ const DealerLocatorWrapper = styled.div`
   grid-template-columns: calc(${(props) => props.theme.menuSlideoutWidth}) 1fr;
   
   @media (max-width: ${(props) => props.theme.sideBySideLayoutBreakpoint}) { 
-     grid-template-areas:
-      "search"
-      "map";
+     grid-template-areas: ${(props) => props.visible ? `"search map" "map map"` : `"search" "map"`};
+     grid-template-columns: 50vw 50vw;
   }
 `;
 
@@ -285,6 +284,7 @@ const SearchArea = styled.div`
 
 const MapArea = styled.div`
   grid-area: map;
+  position: ${(props) => props.visible ? 'relative' : 'initial'};
 
   @media (max-width: ${(props) => props.theme.sideBySideLayoutBreakpoint}) {
     grid-area: auto;

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ class DealerLocator extends React.Component {
       : DealerDetails;
 
     return (
-      <DealerLocatorWrapper visible={!!this.state.selectedDealer}>
+      <DealerLocatorWrapper isDealerSelected={!!this.state.selectedDealer}>
         <SearchArea>
           <DealerSearch
             google={this.props.google}
@@ -203,7 +203,7 @@ class DealerLocator extends React.Component {
             filterOnlineDealers={this.state.isDealerFilterSelected}
           />
         </ListArea>
-        <MapArea visible={!!this.state.selectedDealer}>
+        <MapArea isDealerSelected={!!this.state.selectedDealer}>
           <DealerMap
             dealers={this.dealersWithSelectedFlag()}
             initialCenter={defaultStartingLocation}
@@ -215,7 +215,7 @@ class DealerLocator extends React.Component {
             apiKey={this.props.apiKey}
           />
         </MapArea>
-        <DealerDetailsWrapper visible={!!this.state.selectedDealer}>
+        <DealerDetailsWrapper isDealerSelected={!!this.state.selectedDealer}>
           <DealerDetailsComponent
             dealer={this.state.selectedDealer}
             close={this.clearSelectedDealer}
@@ -246,8 +246,8 @@ const DealerLocatorWrapper = styled.div`
   grid-template-columns: calc(${(props) => props.theme.menuSlideoutWidth}) 1fr;
   
   @media (max-width: ${(props) => props.theme.sideBySideLayoutBreakpoint}) { 
-     grid-template-areas: ${(props) => props.visible ? `"search map" "map map"` : `"search" "map"`};
-     grid-template-columns: ${(props) => props.visible ? '1fr 30%' : 'none'};
+     grid-template-areas: ${(props) => props.isDealerSelected ? `"search map" "map map"` : `"search" "map"`};
+     grid-template-columns: ${(props) => props.isDealerSelected ? '1fr 30%' : 'none'};
   }
 `;
 
@@ -256,7 +256,7 @@ const DealerDetailsWrapper = styled.div`
   grid-area: search / list / list;
   background: white;
   transition: transform 0.25s ease-in-out;
-  transform: translate(${(props) => (props.visible ? 0 : "calc(-100vw)")});
+  transform: translate(${(props) => (props.isDealerSelected ? 0 : "calc(-100vw)")});
 
   @media (max-width: ${(props) => props.theme.sideBySideLayoutBreakpoint}) {
     position: absolute;
@@ -284,7 +284,7 @@ const SearchArea = styled.div`
 
 const MapArea = styled.div`
   grid-area: map;
-  position: ${(props) => props.visible ? 'relative' : 'initial'};
+  position: ${(props) => props.isDealerSelected ? 'relative' : 'initial'};
 
   @media (max-width: ${(props) => props.theme.sideBySideLayoutBreakpoint}) {
     grid-area: auto;

--- a/src/index.js
+++ b/src/index.js
@@ -247,7 +247,7 @@ const DealerLocatorWrapper = styled.div`
   
   @media (max-width: ${(props) => props.theme.sideBySideLayoutBreakpoint}) { 
      grid-template-areas: ${(props) => props.visible ? `"search map" "map map"` : `"search" "map"`};
-     grid-template-columns: 50vw 50vw;
+     grid-template-columns: 75vw 25vw;
   }
 `;
 

--- a/src/index.js
+++ b/src/index.js
@@ -247,7 +247,7 @@ const DealerLocatorWrapper = styled.div`
   
   @media (max-width: ${(props) => props.theme.sideBySideLayoutBreakpoint}) { 
      grid-template-areas: ${(props) => props.visible ? `"search map" "map map"` : `"search" "map"`};
-     grid-template-columns: 75vw 25vw;
+     grid-template-columns: ${(props) => props.visible ? '1fr 30%' : 'none'};
   }
 `;
 


### PR DESCRIPTION
This uses the visible prop in the `MapArea` and `DealerLocatorWrapper` to handle the grid area arrangement on the mobile breakpoint to fix the weird flyout card behavior when selecting a map icon.