### PR TITLE
Make Dealer Details look like it does on Reserve

### DIFF
--- a/src/dealer-details.js
+++ b/src/dealer-details.js
@@ -36,17 +36,19 @@ const DealerDetails = ({ dealer, close, closeButton, websiteButton }) => {
   return (
     <div>
       <CloseDealerButton>
-       <div onClick={close}>{closeButton}</div>
+        <div onClick={close}>{closeButton}</div>
       </CloseDealerButton>
       <DealerTextArea>
+        <DealerName>{dealer.name}</DealerName>
         <Details>
-            <DealerName>{dealer.name}</DealerName>
-            <DealerDetailRow>
+          <DealerDetailRow>
+            <DealerAddress>
               <div>{dealer.addr1}</div>
               <div>{`${dealer.city} ${dealer.city ? "," : ""} ${dealer.state} ${
                 dealer.zip
               } ${dealer.country}`}</div>
-            </DealerDetailRow>
+            </DealerAddress>
+          </DealerDetailRow>
 
           <DealerDetailRow>
             <DealerContact>
@@ -104,6 +106,11 @@ const DealerContact = styled.div`
   max-width: 300px;
 `;
 
+const DealerAddress = styled.div`
+  display: flex;
+  flex-flow: column;
+`;
+
 const Icon = styled(FontAwesomeIcon)`
   margin-left: 5px;
 `;
@@ -117,18 +124,14 @@ const CloseDealerButton = styled.div`
 
 const DealerTextArea = styled.div`
   padding-right: 20px;
-  
-  div {
-    display: flex;
-    flex-flow: column;
-    align-items: center;
-  }
 `;
 
 const DealerName = styled.h1``;
 
 const DealerDetailRow = styled.div`
   margin-top: 20px;
+  display: flex;
+  align-items: flex-start;
 `;
 
 const Website = styled(DealerDetailRow)`


### PR DESCRIPTION
This PR makes some tweaks to the Dealer Details component to recreate the styling currently used on Reserve.

<img width="882" alt="Screen Shot 2020-10-15 at 2 40 08 PM" src="https://user-images.githubusercontent.com/1573349/96183618-5c671280-0ef4-11eb-8921-8781ca4aa694.png">
