### PR TITLE
Check for address fields in Dealer Details

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@apsummers @thundercat1 @alfajor

--- a/src/dealer-details.js
+++ b/src/dealer-details.js
@@ -46,7 +46,7 @@ const DealerDetails = ({ dealer, close, closeButton, websiteButton }) => {
               <div>{dealer.addr1}</div>
               <div>
                 {dealer.city ? `${dealer.city}, ` : ""}
-                {dealer.state ? `${dealer.state}, ` : ""}
+                {dealer.state ? `${dealer.state} ` : ""}
                 {dealer.zip ? `${dealer.zip} ` : ""}
                 {dealer.country ? `${dealer.country}` : ""}
               </div>

--- a/src/dealer-details.js
+++ b/src/dealer-details.js
@@ -44,9 +44,12 @@ const DealerDetails = ({ dealer, close, closeButton, websiteButton }) => {
           <DealerDetailRow>
             <DealerAddress>
               <div>{dealer.addr1}</div>
-              <div>{`${dealer.city} ${dealer.city ? "," : ""} ${dealer.state} ${
-                dealer.zip
-              } ${dealer.country}`}</div>
+              <div>
+                {dealer.city ? `${dealer.city}, ` : ""}
+                {dealer.state ? `${dealer.state}, ` : ""}
+                {dealer.zip ? `${dealer.zip} ` : ""}
+                {dealer.country ? `${dealer.country}` : ""}
+              </div>
             </DealerAddress>
           </DealerDetailRow>
 


### PR DESCRIPTION
This PR checks for every address field before displaying something. This PR was mostly in support of the same thing for scb-static, but it also fixes a small visual error where City was displayed as `City ,`, not `City,` (see line 47 of the deleted diff).